### PR TITLE
Fix FetchTeamPoints return documentation

### DIFF
--- a/R/FetchTeamPoints.R
+++ b/R/FetchTeamPoints.R
@@ -6,7 +6,7 @@
 #' @param LeagueCode A string representing the league code.
 #' @param LastGW An integer representing the last gameweek to fetch.
 #'
-#' @return A data.table with team value data tagged by gameweek.
+#' @return A data.table with team points data tagged by gameweek.
 FetchTeamPoints <- function(LeagueCode, LastGW) {
   gws <- seq_len(as.integer(LastGW))
   fetched <- lapply(gws, function(gw) {


### PR DESCRIPTION
## Summary
- Correct the FetchTeamPoints roxygen `@return` description from team value to team points data.

## Testing
- `R -q -e "devtools::document()"` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac323448a0833296cf0c482401600a