### PR TITLE
Add helpers for gameweek player stats and league totals

### DIFF
--- a/R/FPLGetGameweekPlayerStats.R
+++ b/R/FPLGetGameweekPlayerStats.R
@@ -1,0 +1,15 @@
+#' Retrieve player statistics for a gameweek
+#'
+#' @param GW Gameweek number.
+#'
+#' @return A data.table with player statistics for the specified gameweek.
+FPLGetGameweekPlayerStats <- function(GW){
+  LiveData <- FPLAPIGetGWLive(GW)
+  StatsList <- lapply(LiveData$elements, function(x){
+    data.table(PlayerId = x$id, x$stats)
+  })
+  Stats <- rbindlist(StatsList, fill = TRUE)
+  PlayerInfo <- FPLGetPlayerInfo()[, .(PlayerId = id, web_name)]
+  Stats[PlayerInfo, on = "PlayerId", Name := i.web_name]
+  return(Stats)
+}

--- a/R/FPLGetLeagueGameweekTotals.R
+++ b/R/FPLGetLeagueGameweekTotals.R
@@ -1,0 +1,27 @@
+#' Retrieve gameweek totals for each manager in a league
+#'
+#' @param LeagueCode League code to query.
+#' @param GW Gameweek number.
+#'
+#' @return A data.table of total points per manager including display names.
+FPLGetLeagueGameweekTotals <- function(LeagueCode, GW){
+  League <- FPLAPIGetLeagueStandings(LeagueCode)
+  Standings <- rbindlist(League$standings$results)[, .(EntryId = entry, DisplayName = player_name)]
+  PlayerIds <- Standings$EntryId
+  ListOfTeams <- lapply(PlayerIds, function(id){
+    Picks <- rbindlist(FPLAPIGetPlayerGWPicks(id, GW)$picks)
+    Picks[, EntryId := id]
+    return(Picks)
+  })
+  Picks <- rbindlist(ListOfTeams)
+  setnames(Picks, "element", "PlayerId")
+
+  PlayerTotals <- FPLGetGameweekPlayerStats(GW)[, .(PlayerId, Points = total_points)]
+  Picks[PlayerTotals, on = "PlayerId", Points := i.Points]
+  Picks[, GWPoints := Points * multiplier]
+
+  Totals <- Picks[, .(Points = sum(GWPoints, na.rm = TRUE)), by = EntryId]
+  Totals[Standings, on = "EntryId", DisplayName := i.DisplayName]
+  Totals <- Totals[order(-Points)]
+  return(Totals)
+}


### PR DESCRIPTION
## Summary
- Add `FPLGetGameweekPlayerStats` to fetch live player stats while retaining PlayerId
- Add `FPLGetLeagueGameweekTotals` to compute manager totals without redundant player info lookup and include display names

## Testing
- `R -q -e "install.packages(c('httr','data.table','jsonlite'), repos='https://cloud.r-project.org')"` *(fails: command not found: R)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51048c5483328af242c3719780f2