### PR TITLE
Validate numeric inputs and handle API failures

### DIFF
--- a/R/FPLAPIGetGWLive.R
+++ b/R/FPLAPIGetGWLive.R
@@ -1,9 +1,15 @@
 #' Retrieve live gameweek data
 #'
-#' @param GW Gameweek number.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return Parsed live data.
+#' @details Throws an error if no data is returned for the gameweek.
 FPLAPIGetGWLive <- function(GW, ...) {
-  .FPLAPIGet(paste0("/event/", GW, "/live/"), ...)
+  .assert_single_integer(GW, "GW")
+  res <- .FPLAPIGet(paste0("/event/", GW, "/live/"), ...)
+  if (length(res) == 0) {
+    stop("No live data returned for gameweek ", GW)
+  }
+  res
 }
 

--- a/R/FPLAPIGetHeaderData.R
+++ b/R/FPLAPIGetHeaderData.R
@@ -1,7 +1,12 @@
 #' Retrieve bootstrap header information
 #'
 #' @return Parsed bootstrap header data.
+#' @details Throws an error if no data is returned.
 FPLAPIGetHeaderData <- function(...) {
-  .FPLAPIGet("/bootstrap-static/", ...)
+  res <- .FPLAPIGet("/bootstrap-static/", ...)
+  if (length(res) == 0) {
+    stop("No header data returned.")
+  }
+  res
 }
 

--- a/R/FPLAPIGetLeagueStandings.R
+++ b/R/FPLAPIGetLeagueStandings.R
@@ -1,9 +1,15 @@
 #' Retrieve standings for a classic league
 #'
-#' @param LeagueCode League code to query.
+#' @param LeagueCode League code to query. Must be a single integer.
 #'
 #' @return Parsed league standings.
+#' @details Throws an error if no data is returned.
 FPLAPIGetLeagueStandings <- function(LeagueCode, ...) {
-  .FPLAPIGet(paste0("/leagues-classic/", LeagueCode, "/standings/"), ...)
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  res <- .FPLAPIGet(paste0("/leagues-classic/", LeagueCode, "/standings/"), ...)
+  if (length(res) == 0) {
+    stop("No league standings returned for code ", LeagueCode)
+  }
+  res
 }
 

--- a/R/FPLAPIGetPlayerGWPicks.R
+++ b/R/FPLAPIGetPlayerGWPicks.R
@@ -1,10 +1,17 @@
 #' Retrieve player picks for a given gameweek
 #'
-#' @param PlayerId Player ID.
-#' @param GW Gameweek number.
+#' @param PlayerId Player ID. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return Parsed player picks data.
+#' @details Throws an error if no data is returned.
 FPLAPIGetPlayerGWPicks <- function(PlayerId, GW, ...) {
-  .FPLAPIGet(paste0("/entry/", PlayerId, "/event/", GW, "/picks"), ...)
+  .assert_single_integer(PlayerId, "PlayerId")
+  .assert_single_integer(GW, "GW")
+  res <- .FPLAPIGet(paste0("/entry/", PlayerId, "/event/", GW, "/picks"), ...)
+  if (length(res) == 0) {
+    stop("No picks data returned for player ", PlayerId, " in gameweek ", GW)
+  }
+  res
 }
 

--- a/R/FPLAPIGetPlayerTransfers.R
+++ b/R/FPLAPIGetPlayerTransfers.R
@@ -1,9 +1,15 @@
 #' Retrieve transfers for a player
 #'
-#' @param PlayerId Player ID.
+#' @param PlayerId Player ID. Must be a single integer.
 #'
 #' @return Parsed transfer data.
+#' @details Throws an error if no data is returned.
 FPLAPIGetPlayerTransfers <- function(PlayerId, ...) {
-  .FPLAPIGet(paste0("/entry/", PlayerId, "/transfers"), ...)
+  .assert_single_integer(PlayerId, "PlayerId")
+  res <- .FPLAPIGet(paste0("/entry/", PlayerId, "/transfers"), ...)
+  if (length(res) == 0) {
+    stop("No transfer data returned for player ", PlayerId)
+  }
+  res
 }
 

--- a/R/FPLCompareCaptains.R
+++ b/R/FPLCompareCaptains.R
@@ -2,8 +2,8 @@
 #'
 #' Downloads captain choices for the current and previous gameweek, and compares them.
 #'
-#' @param LeagueCode Integer, the FPL league code.
-#' @param GW Integer, the current gameweek (must be > 1).
+#' @param LeagueCode Integer, the FPL league code. Must be a single integer.
+#' @param GW Integer, the current gameweek (must be > 1). Must be a single integer.
 #'
 #' @return A data.table showing each team's captain choice this week vs last week.
 #' @examples
@@ -11,6 +11,8 @@
 #'   CompareCaptains(721349, GW = 3)
 #' }
 FPLCompareCaptains <- function(LeagueCode, GW) {
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
   if (GW <= 1) {
     stop("Gameweek must be greater than 1 to compare.")
   }

--- a/R/FPLGetCaptains.R
+++ b/R/FPLGetCaptains.R
@@ -2,13 +2,18 @@
 #'
 #' Obtain a data table of players marked as captains in a given league and gameweek.
 #'
-#' @param LeagueCode FPL league code to query.
-#' @param GW Gameweek number.
+#' @param LeagueCode FPL league code to query. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table filtered to players flagged as captains for the specified gameweek.
-#'
+#' @details Throws an error if the data cannot be retrieved.
+
 FPLGetCaptains <- function(LeagueCode, GW){
-  Players <- FPLGetSelectedPlayersForALeague(LeagueCode,GW)
-  Output <- Players[is_captain == TRUE]
-  return(Output)
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
+  res <- FPLGetSelectedPlayersForALeague(LeagueCode, GW)
+  if (!is.data.table(res) || nrow(res) == 0) {
+    stop("No player data returned for league")
+  }
+  res[is_captain == TRUE]
 }

--- a/R/FPLGetCurrentGW.R
+++ b/R/FPLGetCurrentGW.R
@@ -4,13 +4,16 @@
 #'
 #' @return A list with elements `current`, `next`, and `finished` containing
 #'   the respective gameweek numbers.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetCurrentGW <- function() {
   data <- FPLAPIGetHeaderData()
+  if (length(data) == 0) {
+    stop("Failed to retrieve current gameweek information.")
+  }
   GW <- as.data.table(data$events)
-  Output <- list(
+  list(
     current = GW[is_current == TRUE, id],
     `next` = GW[is_next == TRUE, id],
     finished = GW[finished == TRUE, max(id, na.rm = TRUE)]
   )
-  return(Output)
 }

--- a/R/FPLGetGameweekPoints.R
+++ b/R/FPLGetGameweekPoints.R
@@ -1,10 +1,15 @@
 #' Retrieve live player points for a gameweek
 #'
-#' @param GW Gameweek number.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table of player points for the specified gameweek.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetGameweekPoints <- function(GW){
+  .assert_single_integer(GW, "GW")
   y <- FPLAPIGetGWLive(GW)
+  if (length(y) == 0 || is.null(y$elements)) {
+    stop("Failed to retrieve gameweek points.")
+  }
   ListOfData <- lapply(X = y$elements, function(x){
     data.table(id = x$id, Points = x$stats$total_points)
   })

--- a/R/FPLGetLeagueInfo.R
+++ b/R/FPLGetLeagueInfo.R
@@ -1,10 +1,15 @@
 #' Retrieve standings for an FPL league
 #'
-#' @param LeagueCode Integer league code to query.
+#' @param LeagueCode Integer league code to query. Must be a single integer.
 #'
 #' @return A data.table of league standings.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetLeagueInfo <- function(LeagueCode = 997983){
+  .assert_single_integer(LeagueCode, "LeagueCode")
   LeagueInfo <- FPLAPIGetLeagueStandings(LeagueCode)
+  if (length(LeagueInfo) == 0 || is.null(LeagueInfo$standings$results)) {
+    stop("Failed to retrieve league information.")
+  }
   LeaguesTable <- rbindlist(LeagueInfo$standings$results)
   setnames(LeaguesTable, "entry", "PlayerId")
   return(LeaguesTable)

--- a/R/FPLGetMostSelectedPlayers.R
+++ b/R/FPLGetMostSelectedPlayers.R
@@ -1,11 +1,17 @@
 #' Most selected players in a league
 #'
-#' @param LeagueCode League code to query.
-#' @param GW Gameweek number.
+#' @param LeagueCode League code to query. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table with player names and selection counts.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetMostSelectedPlayers <- function(LeagueCode, GW){
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
   Players <- FPLGetSelectedPlayersForALeague(LeagueCode,GW)
+  if (!is.data.table(Players) || nrow(Players) == 0) {
+    stop("No player data returned for league")
+  }
   Output <- Players[Status == "Selected", .N, by = Name][order(-N)]
   return(Output)
 }

--- a/R/FPLGetPlayerInfo.R
+++ b/R/FPLGetPlayerInfo.R
@@ -1,8 +1,12 @@
 #' Retrieve static player information
 #'
 #' @return A data.table with player metadata.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetPlayerInfo <- function(){
   StaticInfo <- FPLAPIGetHeaderData()
+  if (length(StaticInfo) == 0 || is.null(StaticInfo$elements)) {
+    stop("Failed to retrieve player information.")
+  }
   StaticInfoTable <- rbindlist(StaticInfo$elements)
   return(StaticInfoTable)
 }

--- a/R/FPLGetSelectedPlayersForALeague.R
+++ b/R/FPLGetSelectedPlayersForALeague.R
@@ -1,15 +1,23 @@
 #' Retrieve selected players for all teams in a league
 #'
-#' @param LeagueCode League code to query.
-#' @param GW Gameweek number.
+#' @param LeagueCode League code to query. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table with player selections for each manager.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetSelectedPlayersForALeague <- function(LeagueCode, GW){
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
   LeagueInfo <- FPLGetLeagueInfo(LeagueCode)
+  if (!is.data.table(LeagueInfo) || nrow(LeagueInfo) == 0) {
+    stop("Failed to retrieve league information.")
+  }
   PlayerIds <- LeagueInfo$PlayerId
   names(PlayerIds) <- LeagueInfo$player_name
   ListOfTeams <- lapply(X = PlayerIds, FUN = FPLGetUserTeam, GW = GW)
   TeamTable <- rbindlist(ListOfTeams, idcol = "player_name")
-  Output <- TeamTable[, list(player_name, Name, Status, is_captain)]
-  return(Output)
+  if (!is.data.table(TeamTable) || nrow(TeamTable) == 0) {
+    stop("No player selections returned for league")
+  }
+  TeamTable[, list(player_name, Name, Status, is_captain)]
 }

--- a/R/FPLGetTeamPoints.R
+++ b/R/FPLGetTeamPoints.R
@@ -1,15 +1,22 @@
 #' Retrieve team points for a league and gameweek
 #'
-#' @param LeagueCode League code to query.
-#' @param GW Gameweek number.
+#' @param LeagueCode League code to query. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table of total points per manager.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetTeamPoints <- function(LeagueCode,GW){
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
   LeagueInfo <- FPLGetLeagueInfo(LeagueCode=LeagueCode)
+  if (!is.data.table(LeagueInfo) || nrow(LeagueInfo) == 0) {
+    stop("Failed to retrieve league information.")
+  }
   PlayerIds <- LeagueInfo$PlayerId
   names(PlayerIds) <- LeagueInfo$player_name
   ListOfTeams <- lapply(X = PlayerIds, FUN = function(x){
     y <- FPLAPIGetPlayerGWPicks(x, GW)
+    if (length(y) == 0 || is.null(y$entry_history$points)) return(NA)
     y$entry_history$points
   })
   TeamTable <- t(data.frame(ListOfTeams))

--- a/R/FPLGetTeamValue.R
+++ b/R/FPLGetTeamValue.R
@@ -1,15 +1,22 @@
 #' Retrieve team values for a league and gameweek
 #'
-#' @param LeagueCode League code to query.
-#' @param GW Gameweek number.
+#' @param LeagueCode League code to query. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table of team values per manager.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetTeamValue <- function(LeagueCode,GW){
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
   LeagueInfo <- FPLGetLeagueInfo(LeagueCode=LeagueCode)
+  if (!is.data.table(LeagueInfo) || nrow(LeagueInfo) == 0) {
+    stop("Failed to retrieve league information.")
+  }
   PlayerIds <- LeagueInfo$PlayerId
   names(PlayerIds) <- LeagueInfo$player_name
   ListOfTeams <- lapply(X = PlayerIds, FUN = function(x){
     y <- FPLAPIGetPlayerGWPicks(x, GW)
+    if (length(y) == 0 || is.null(y$entry_history$value)) return(NA)
     y$entry_history$value
   })
   TeamTable <- t(data.frame(ListOfTeams))

--- a/R/FPLGetTransfers.R
+++ b/R/FPLGetTransfers.R
@@ -1,15 +1,22 @@
 #' Retrieve transfers made by managers in a league
 #'
-#' @param LeagueCode League code to query.
-#' @param GW Gameweek number.
+#' @param LeagueCode League code to query. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table detailing transfers for the specified gameweek.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetTransfers <- function(LeagueCode, GW){
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(GW, "GW")
   LeagueInfo <- FPLGetLeagueInfo(LeagueCode=LeagueCode)
+  if (!is.data.table(LeagueInfo) || nrow(LeagueInfo) == 0) {
+    stop("Failed to retrieve league information.")
+  }
   PlayerIds <- LeagueInfo$PlayerId
   names(PlayerIds) <- LeagueInfo$player_name
   TransfersList  <- lapply(X = PlayerIds, FUN = function(x){
     y <- FPLAPIGetPlayerTransfers(x)
+    if (length(y) == 0) return(data.table())
     rbindlist(y)
   })
   Transfers <- rbindlist(TransfersList)
@@ -19,6 +26,9 @@ FPLGetTransfers <- function(LeagueCode, GW){
   Transfers[PlayerInfo, on = list(element_in = id), PlayerIn := i.web_name]
   Transfers[PlayerInfo, on = list(element_out = id), PlayerOut := i.web_name]
   setnames(Transfers, "event", "GW")
-  Output <- Transfers[GW == ..GW, list(Name, PlayerOut, CostOut = element_out_cost/10, PlayerIn, CostIn = element_in_cost/10)]
-  return(Output)
+  res <- Transfers[GW == ..GW, list(Name, PlayerOut, CostOut = element_out_cost/10, PlayerIn, CostIn = element_in_cost/10)]
+  if (!is.data.table(res) || nrow(res) == 0) {
+    stop("No transfers found for gameweek ", GW)
+  }
+  return(res)
 }

--- a/R/FPLGetUserTeam.R
+++ b/R/FPLGetUserTeam.R
@@ -1,13 +1,22 @@
 #' Retrieve a user's team for a gameweek
 #'
-#' @param PlayerId Player ID of the manager.
-#' @param GW Gameweek number.
+#' @param PlayerId Player ID of the manager. Must be a single integer.
+#' @param GW Gameweek number. Must be a single integer.
 #'
 #' @return A data.table of the user's squad with names and selection status.
+#' @details Throws an error if the data cannot be retrieved.
 FPLGetUserTeam <- function(PlayerId, GW){
+  .assert_single_integer(PlayerId, "PlayerId")
+  .assert_single_integer(GW, "GW")
   y <- FPLAPIGetPlayerGWPicks(PlayerId, GW)
+  if (length(y) == 0 || is.null(y$picks)) {
+    stop("Failed to retrieve user team.")
+  }
   Picks <- rbindlist(y$picks)
   PlayerInfo <- FPLGetPlayerInfo()
+  if (!is.data.table(PlayerInfo) || nrow(PlayerInfo) == 0) {
+    stop("Player information unavailable.")
+  }
   Picks[PlayerInfo, on = list(element = id),Name := i.web_name]
   Picks[, Status := fifelse(position %in% 1:11, "Selected","Bench")]
   return(Picks)

--- a/R/FetchTeamPoints.R
+++ b/R/FetchTeamPoints.R
@@ -3,25 +3,25 @@
 #' Fetches team points data for each gameweek from 1 to LastGW using FPLGetTeamPoints().
 #' Combines the results from each gameweek into a single data.table.
 #'
-#' @param LeagueCode A string representing the league code.
-#' @param LastGW An integer representing the last gameweek to fetch.
+#' @param LeagueCode A string representing the league code. Must be a single integer.
+#' @param LastGW An integer representing the last gameweek to fetch. Must be a single integer.
 #'
 #' @return A data.table with team points data tagged by gameweek.
+#' @details Throws an error if data for any gameweek cannot be retrieved.
 FetchTeamPoints <- function(LeagueCode, LastGW) {
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(LastGW, "LastGW")
   gws <- seq_len(as.integer(LastGW))
   fetched <- lapply(gws, function(gw) {
-    res <- tryCatch(
-      FPLGetTeamPoints(LeagueCode = LeagueCode, GW = gw),
-      error = function(e) {
-        stop(paste0("Error fetching data for GW ", gw, ": ", e$message))
-      }
-    )
-    if (is.null(res)) stop(paste0("FPLGetTeamPoints returned NULL for GW ", gw))
-    return(res)
+    res <- FPLGetTeamPoints(LeagueCode = LeagueCode, GW = gw)
+    if (!is.data.table(res) || nrow(res) == 0) {
+      stop("No team points returned for GW ", gw)
+    }
+    res
   })
 
   # Combine fetched results into a single data.table; each record tagged with its gameweek
-  combined <- rbindlist(l = fetched, idcol = "GW")
+  combined <- rbindlist(l = fetched, idcol = "GW", fill = TRUE)
 
   combined[order(rn), CumPoints := cumsum(Points), by = rn]
 

--- a/R/FetchTeamValues.R
+++ b/R/FetchTeamValues.R
@@ -3,25 +3,25 @@
 #' Fetches team value data for each gameweek from 1 to LastGW using FPLGetTeamValue().
 #' Combines the results from each gameweek into a single data.table.
 #'
-#' @param LeagueCode A string representing the league code.
-#' @param LastGW An integer representing the last gameweek to fetch.
+#' @param LeagueCode A string representing the league code. Must be a single integer.
+#' @param LastGW An integer representing the last gameweek to fetch. Must be a single integer.
 #'
 #' @return A data.table with team value data tagged by gameweek.
+#' @details Throws an error if data for any gameweek cannot be retrieved.
 FetchTeamValues <- function(LeagueCode, LastGW) {
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(LastGW, "LastGW")
   gws <- seq_len(as.integer(LastGW))
   fetched <- lapply(gws, function(gw) {
-    res <- tryCatch(
-      FPLGetTeamValue(LeagueCode = LeagueCode, GW = gw),
-      error = function(e) {
-        stop(paste0("Error fetching data for GW ", gw, ": ", e$message))
-      }
-    )
-    if (is.null(res)) stop(paste0("FPLGetTeamValue returned NULL for GW ", gw))
-    return(res)
+    res <- FPLGetTeamValue(LeagueCode = LeagueCode, GW = gw)
+    if (!is.data.table(res) || nrow(res) == 0) {
+      stop("No team value returned for GW ", gw)
+    }
+    res
   })
 
   # Combine fetched results into a single data.table; each record tagged with its gameweek
-  combined <- rbindlist(l = fetched, idcol = "GW")
+  combined <- rbindlist(l = fetched, idcol = "GW", fill = TRUE)
 
   return(combined)
 }

--- a/R/PlotTeamPointsOverTime.R
+++ b/R/PlotTeamPointsOverTime.R
@@ -1,10 +1,12 @@
 #' Integrates data fetching, validation, plotting, and color selection into a single function to produce a refined plot of team points over time.
 #'
-#' @param LeagueCode A string representing the league code.
-#' @param LastGW An integer representing the last game week to fetch and visualize.
+#' @param LeagueCode A string representing the league code. Must be a single integer.
+#' @param LastGW An integer representing the last game week to fetch and visualize. Must be a single integer.
 #'
 #' @return A ggplot object visualizing team points trends with team-specific colors.
 PlotTeamPointsOverTime <- function(LeagueCode, LastGW, Average = FALSE) {
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(LastGW, "LastGW")
   # Fetch team value data
   data <- FetchTeamPoints(LeagueCode, LastGW)
 

--- a/R/PlotTeamValueOverTime.R
+++ b/R/PlotTeamValueOverTime.R
@@ -1,10 +1,12 @@
 #' Integrates data fetching, validation, plotting, and color selection into a single function to produce a refined plot of team values over time.
 #'
-#' @param LeagueCode A string representing the league code.
-#' @param LastGW An integer representing the last game week to fetch and visualize.
+#' @param LeagueCode A string representing the league code. Must be a single integer.
+#' @param LastGW An integer representing the last game week to fetch and visualize. Must be a single integer.
 #'
 #' @return A ggplot object visualizing team value trends with team-specific colors.
 PlotTeamValueOverTime <- function(LeagueCode, LastGW) {
+  .assert_single_integer(LeagueCode, "LeagueCode")
+  .assert_single_integer(LastGW, "LastGW")
   # Fetch team value data
   data <- FetchTeamValues(LeagueCode, LastGW)
 

--- a/R/internal-FPLAPIGet.R
+++ b/R/internal-FPLAPIGet.R
@@ -7,12 +7,17 @@
 #' @param ... Additional arguments passed to httr::GET.
 #'
 #' @return Parsed response content.
+#' @details Throws an informative error if the request fails.
 #' @noRd
 .FPLAPIGet <- function(endpoint, ...) {
   base <- "https://fantasy.premierleague.com/api"
   url <- paste0(base, endpoint)
-  resp <- GET(url = url, ...)
-  stop_for_status(resp)
-  content(resp)
+  tryCatch({
+    resp <- GET(url = url, ...)
+    stop_for_status(resp)
+    content(resp)
+  }, error = function(e) {
+    stop("API request failed: ", e$message)
+  })
 }
 

--- a/R/utils-assert.R
+++ b/R/utils-assert.R
@@ -1,0 +1,15 @@
+#' Validate a length-one integer parameter
+#'
+#' Ensures that a numeric parameter is a length-one integer.
+#'
+#' @param x The object to validate.
+#' @param name Parameter name for informative error messages.
+#'
+#' @return TRUE invisibly if validation passes; otherwise an error is thrown.
+#' @noRd
+.assert_single_integer <- function(x, name) {
+  if (!is.numeric(x) || length(x) != 1 || is.na(x) || x %% 1 != 0) {
+    stop(paste0(name, " must be a length-one integer."), call. = FALSE)
+  }
+  invisible(TRUE)
+}


### PR DESCRIPTION
## Summary
- throw informative errors when FPL API responses return no data
- keep length-one integer checks for numeric parameters and document error behavior
- ensure helper functions stop on missing gameweek data instead of returning empties
- build integer validation error messages using paste0 instead of sprintf

## Testing
- `apt-get update` *(fails: repository not signed, 403)*
- `apt-get install -y r-base` *(fails: Unable to locate package r-base)*
- `R CMD check --no-manual --no-build-vignettes .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac510a2b3083328e8bb3320caefd1e