### PR TITLE
Refactor modal XI selection via shared helper

### DIFF
--- a/R/FPLGetLeagueModalXI.R
+++ b/R/FPLGetLeagueModalXI.R
@@ -17,19 +17,6 @@ FPLGetLeagueModalXI <- function(LeagueCode, GW){
   Counts[PlayerInfo, on = list(element = PlayerId), `:=`(WebName = i.WebName,
                                                          ElementType = i.ElementType)]
   setnames(Counts, old = c("element", "N"), new = c("PlayerId", "SelectedCount"))
-  setorder(Counts, -SelectedCount)
 
-  GK  <- Counts[ElementType == 1][1]
-  DEF <- Counts[ElementType == 2][1:3]
-  MID <- Counts[ElementType == 3][1]
-  FWD <- Counts[ElementType == 4][1]
-  Picked <- rbindlist(list(GK, DEF, MID, FWD))
-
-  Remaining <- Counts[!PlayerId %in% Picked$PlayerId]
-  SpotsLeft <- 11 - nrow(Picked)
-  if (SpotsLeft > 0) {
-    Picked <- rbind(Picked, Remaining[1:SpotsLeft])
-  }
-
-  return(Picked)
+  .BuildModalXI(Counts, SelectedCount)
 }

--- a/R/FPLGetModalXIWorld.R
+++ b/R/FPLGetModalXIWorld.R
@@ -17,19 +17,6 @@ FPLGetModalXIWorld <- function(GW = FPLGetCurrentGW()$current){
       Team = team,
       ElementType = element_type,
       SelectedByPercent = as.numeric(selected_by_percent))]
-  setorder(Info, -SelectedByPercent)
 
-  GK  <- Info[ElementType == 1][1]
-  DEF <- Info[ElementType == 2][1:3]
-  MID <- Info[ElementType == 3][1]
-  FWD <- Info[ElementType == 4][1]
-  Picked <- rbindlist(list(GK, DEF, MID, FWD))
-
-  Remaining <- Info[!PlayerId %in% Picked$PlayerId]
-  SpotsLeft <- 11 - nrow(Picked)
-  if (SpotsLeft > 0) {
-    Picked <- rbind(Picked, Remaining[1:SpotsLeft])
-  }
-
-  return(Picked)
+  .BuildModalXI(Info, SelectedByPercent)
 }

--- a/R/internal-BuildModalXI.R
+++ b/R/internal-BuildModalXI.R
@@ -1,0 +1,31 @@
+#' Build a modal XI from candidate players
+#'
+#' Helper for selecting a starting XI based on a selection metric while
+#' honouring squad composition rules (one goalkeeper, three defenders, one
+#' midfielder and one forward). Remaining spots are filled by the highest
+#' selection metric regardless of position.
+#'
+#' @param players data.table of candidate players. Must contain columns
+#'   `PlayerId`, `ElementType` and the column referenced by `metric`.
+#' @param metric Column containing the selection metric (unquoted).
+#'
+#' @return data.table of the chosen XI.
+#' @noRd
+.BuildModalXI <- function(players, metric) {
+  metric_col <- deparse(substitute(metric))
+  setorder(players, -get(metric_col))
+
+  GK  <- players[ElementType == 1][1]
+  DEF <- players[ElementType == 2][1:3]
+  MID <- players[ElementType == 3][1]
+  FWD <- players[ElementType == 4][1]
+  picked <- rbindlist(list(GK, DEF, MID, FWD))
+
+  remaining <- players[!PlayerId %in% picked$PlayerId]
+  spots_left <- 11 - nrow(picked)
+  if (spots_left > 0) {
+    picked <- rbind(picked, remaining[1:spots_left])
+  }
+
+  picked
+}


### PR DESCRIPTION
## Summary
- add internal `.BuildModalXI` helper to assemble a squad based on a selection metric using PascalCase naming
- refactor `FPLGetLeagueModalXI` and `FPLGetModalXIWorld` to use the shared helper

## Testing
- `R CMD check --no-manual --as-cran .` *(fails: command not found: R)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac56d1bca48332a7962093e8ae85c9